### PR TITLE
Allow reducer function to be passed to kea reducers.

### DIFF
--- a/src/kea/logic/reducer.js
+++ b/src/kea/logic/reducer.js
@@ -57,7 +57,7 @@ export function convertReducerArrays (reducers) {
       let reducerObject = {
         value: value,
         type: type,
-        reducer: createReducer(reducer, value)
+        reducer: typeof reducer === 'function' ? reducer : createReducer(reducer, value)
       }
 
       if (options) {


### PR DESCRIPTION
Add back in functionality to allow a reducer to be passed directly to the kea reducers configuration.

Allows use case:

reducers.js
```
export default createReducer({
  myAction: (state, payload) => {
    ...
  }
}, {})
```

logic.js
```
import reducer from './reducer.js'

export default kea({
  reducers: ({ actions, constants }) => ({
    myReducer: [null, PropTypes.object, reducer],
  })
})
```