### PR TITLE
Bugfix/prevent object creation

### DIFF
--- a/src/__tests__/__snapshots__/snapshot.js.snap
+++ b/src/__tests__/__snapshots__/snapshot.js.snap
@@ -24,4 +24,4 @@ exports[`snapshots must match 1`] = `
     updateName
   </div>
 </div>
-`;
+`

--- a/src/kea/logic/reducer.js
+++ b/src/kea/logic/reducer.js
@@ -21,6 +21,8 @@ export function createReducer (mapping, defaultValue) {
   }
 }
 
+const emptyObj = {}
+
 // input: object with values: { value, type, reducer, ...options } or function(state, action) {}
 // output: combined reducer function (state, action) {}
 export function combineReducerObjects (path, objects) {
@@ -33,7 +35,7 @@ export function combineReducerObjects (path, objects) {
   if (Object.keys(reducers).length > 0) {
     return combineReducers(reducers)
   } else {
-    return () => ({})
+    return () => emptyObj
   }
 }
 


### PR DESCRIPTION
Some of my PureComponents were getting re-rendered every time and the cause turned out to be the `root` selector returning a new object every time.