### PR TITLE
Ensure preloadedState is immutable on store create

### DIFF
--- a/src/kea/store/index.js
+++ b/src/kea/store/index.js
@@ -49,7 +49,7 @@ export function getStore (opts = {}) {
   const combinedReducers = combineReducers(options.reducers)
 
   // create store
-  const store = finalCreateStore(combinedReducers, options.preloadedState)
+  const store = finalCreateStore(combinedReducers, {...options.preloadedState})
 
   // run post-hooks
   globalPlugins.afterReduxStore.forEach(f => f(options, store))


### PR DESCRIPTION
In `getStore` in kea, the `preloadedState` is used as-is, allowing external actors to change the store underneath redux' nose. This specifically WILL happen when using Kea with Next, since the store is created once on the client and new data pushed into it via the Next.js update mechanism. The result is that `react-redux` believes the object has not changed, and components do not update.

Worse, the store is globally available on Window, and the result is that a malicious script would be able to change the store the app believes it is using, without its knowledge.

This change ensures that cannot happen, and retains the redux guarantee of state immutability.