### PR TITLE
Fix stateless detection for arrow functions

### DIFF
--- a/src/kea/index.js
+++ b/src/kea/index.js
@@ -18,7 +18,10 @@ import { firstReducerRoot, isSyncedWithStore, addReducer } from './reducer'
 import { globalPlugins, activatePlugin } from './plugins'
 
 function isStateless (Component) {
-  return !Component.prototype.render
+  return (
+    typeof Component === 'function' && // can be various things
+    !(Component.prototype && Component.prototype.isReactComponent) // native arrows don't have prototypes // special property
+  )
 }
 
 let nonamePathCounter = 0


### PR DESCRIPTION
Should fix up #86 -- especially when running under jest.

A little bit of background: https://stackoverflow.com/questions/41488713/react-how-to-determine-if-component-is-stateless-functional

More future proofed solution is probably using `react-is` but I wasn't sure what your stance on dependencies was so I didn't want to propose that without a conversation. 