### PR TITLE
Check if selector returns any values before trying to access them

### DIFF
--- a/src/core/steps/connect.js
+++ b/src/core/steps/connect.js
@@ -80,7 +80,10 @@ export function createConnect (logic, input) {
           logic.propTypes[to] = otherLogic.propTypes[from]
         }
       } else {
-        logic.selectors[to] = from === '*' ? otherLogic : (state, props) => (otherLogic(state, props) && otherLogic(state, props)[from])
+        logic.selectors[to] = from === '*' ? otherLogic : (state, props) => {
+          const values = otherLogic(state, props)
+          return values && values[from]
+        }
       }
 
       if (process.env.NODE_ENV !== 'production') {

--- a/src/core/steps/connect.js
+++ b/src/core/steps/connect.js
@@ -80,7 +80,7 @@ export function createConnect (logic, input) {
           logic.propTypes[to] = otherLogic.propTypes[from]
         }
       } else {
-        logic.selectors[to] = from === '*' ? otherLogic : (state, props) => otherLogic(state, props)[from]
+        logic.selectors[to] = from === '*' ? otherLogic : (state, props) => (otherLogic(state, props) && otherLogic(state, props)[from])
       }
 
       if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
When connecting to non kea selectors and those reducers are also created lazily (e.g redux-form) the kea connect selector tries to directly access properties and crashes. Should check first if the reducer returns anything before trying to access properties of the result