### PR TITLE
Unmount bug fix

### DIFF
--- a/src/listeners/index.js
+++ b/src/listeners/index.js
@@ -207,11 +207,12 @@ function addListenersByPathString (pathString, listeners) {
 
 function removeListenersByPathString (pathString, listeners) {
   const { byPath, byAction } = getPluginContext('listeners')
-
   Object.entries(listeners).forEach(([action, listener]) => {
-    delete byAction[action][pathString]
-    if (Object.keys(byAction[action]).length === 0) {
-      delete byAction[action]
+    if (byAction[action]) {
+      delete byAction[action][pathString]
+      if (Object.keys(byAction[action]).length === 0) {
+        delete byAction[action]
+      }
     }
   })
 


### PR DESCRIPTION
Hey @mariusandra not sure how `byAction` works or why `byAction[action]` is ever falsey but it sometimes is and when it is, I get lots of errors so I added this check and the errors go away. I noticed this behavior when I started calling `resetContext` multiple times. On the nth call, it unmounts the previous logics and sometimes `byAction` is falsely and errors get thrown.