### PR TITLE
Create store in context getter

### DIFF
--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -62,6 +62,7 @@ export function openContext(options: ContextOptions = {}) {
     },
 
     store: undefined,
+    __store: undefined,
 
     options: {
       debug: false,
@@ -75,6 +76,19 @@ export function openContext(options: ContextOptions = {}) {
       ...otherOptions,
     },
   } as Context
+
+  Object.defineProperty(newContext, 'store', {
+    get: function get() {
+      const store = (newContext as any)['__store']
+      if (!store && createStore) {
+        return getStore(typeof createStore === 'object' ? createStore : {})
+      }
+      return store
+    },
+    set: function set(store) {
+      ;(newContext as any)['__store'] = store
+    },
+  })
 
   setContext(newContext)
 
@@ -90,10 +104,6 @@ export function openContext(options: ContextOptions = {}) {
     for (const plugin of plugins) {
       activatePlugin(plugin)
     }
-  }
-
-  if (createStore) {
-    getStore(typeof createStore === 'object' ? createStore : {})
   }
 
   return context

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -29,7 +29,7 @@ export function getStore(opts = {}) {
     return
   }
 
-  if (context.store) {
+  if (context.__store) {
     console.error('[KEA] Already attached to a store! Exiting. Please reset the context before requesing a store')
     return
   }
@@ -67,7 +67,7 @@ export function getStore(opts = {}) {
 
   // create store
   const store = finalCreateStore(createCombinedReducer(), Object.assign({}, options.preloadedState))
-  context.store = store
+  context.__store = store
 
   // run post-hooks
   runPlugins('afterReduxStore', options, store)


### PR DESCRIPTION
- Create store when first accessed, not on init. 
- Avoids duplicate instance in redux devtools.
- Fixes #111 