### PR TITLE
Kea 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 All notable changes to this project will be documented in this file.
 
 ## 2.4.0 - xxx
+- **Possibly Breaking:** Changed the [default path](https://kea.js.org/docs/guide/debugging#logic-path) for logic 
+  without a `path` (or when not using the kea babel plugin) from `kea.inline` to `kea.logic`. If you have ever hardcoded 
+  `"kea.inline"` anywhere, perhaps in tests, this will cause a bit of headache. If you need it set at `kea.inline`, use 
+  `resetContext({ defaultPath: ['kea', 'inline'] })`.
+
 - TODO: Add `<Provider />` tag to wrap Redux's `<Provider store={getContext().store} />`
 - TODO: Deprecated `resetContext`
-- TODO: Rename `kea.inline` to `kea.logic`
 - TODO: Fix whatever bug is happening with CRA fast refresh
 
 ## 2.3.8 - 2021-04-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
   without a `path` (or when not using the kea babel plugin) from `kea.inline` to `kea.logic`. If you have ever hardcoded 
   `"kea.inline"` anywhere, perhaps in tests, this will cause a bit of headache. If you need it set at `kea.inline`, use 
   `resetContext({ defaultPath: ['kea', 'inline'] })`.
-- Added `<Provider />` tag to simplify calling React-Redux's `<Provider store={getContext().store} />`
+- Added `<Provider />` tag to simplify calling React-Redux's `<Provider store={getContext().store} />`.
+- Fixed crashes with [React Fast Refresh](https://github.com/keajs/kea/issues/119).
 
 ## 2.3.8 - 2021-04-26
 - Fix regression introduced in 2.3.5 with default keys like: `key: props => props.id || 'default'`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ All notable changes to this project will be documented in this file.
   without a `path` (or when not using the kea babel plugin) from `kea.inline` to `kea.logic`. If you have ever hardcoded 
   `"kea.inline"` anywhere, perhaps in tests, this will cause a bit of headache. If you need it set at `kea.inline`, use 
   `resetContext({ defaultPath: ['kea', 'inline'] })`.
-
-- TODO: Add `<Provider />` tag to wrap Redux's `<Provider store={getContext().store} />`
+- Added `<Provider />` tag to simplify calling React-Redux's `<Provider store={getContext().store} />`
 - TODO: Deprecated `resetContext`
 - TODO: Fix whatever bug is happening with CRA fast refresh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## 2.4.0 - xxx
+## 2.4.0 - 2021-05-02
 - **Possibly Breaking:** Changed the [default path](https://kea.js.org/docs/guide/debugging#logic-path) for logic 
   without a `path` (or when not using the kea babel plugin) from `kea.inline` to `kea.logic`. If you have ever hardcoded 
   `"kea.inline"` anywhere, perhaps in tests, this will cause a bit of headache. If you need it set at `kea.inline`, use 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 2.4.0 - xxx
+- TODO: Add `<Provider />` tag to wrap Redux's `<Provider store={getContext().store} />`
+- TODO: Deprecated `resetContext`
+- TODO: Rename `kea.inline` to `kea.logic`
+- TODO: Fix whatever bug is happening with CRA fast refresh
+
 ## 2.3.8 - 2021-04-26
 - Fix regression introduced in 2.3.5 with default keys like: `key: props => props.id || 'default'`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ All notable changes to this project will be documented in this file.
   `"kea.inline"` anywhere, perhaps in tests, this will cause a bit of headache. If you need it set at `kea.inline`, use 
   `resetContext({ defaultPath: ['kea', 'inline'] })`.
 - Added `<Provider />` tag to simplify calling React-Redux's `<Provider store={getContext().store} />`
-- TODO: Deprecated `resetContext`
-- TODO: Fix whatever bug is happening with CRA fast refresh
 
 ## 2.3.8 - 2021-04-26
 - Fix regression introduced in 2.3.5 with default keys like: `key: props => props.id || 'default'`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kea",
-  "version": "2.3.8",
+  "version": "2.4.0",
   "description": "Smart front-end architecture",
   "author": "Marius Andra",
   "license": "MIT",

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -77,7 +77,7 @@ export function openContext(options: ContextOptions = {}, initial = false): Cont
       flatDefaults: false,
       attachStrategy: 'dispatch',
       detachStrategy: 'dispatch',
-
+      defaultPath: ['kea', 'logic'],
       ...otherOptions,
     },
   } as Context

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -35,8 +35,8 @@ export function openContext(options: ContextOptions = {}, initial = false): Cont
     },
 
     input: {
-      inlinePathCreators: new Map(),
-      inlinePathCounter: 0,
+      logicPathCreators: new Map(),
+      logicPathCounter: 0,
       defaults: defaults || undefined,
     },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,10 @@ export * from './types'
 import { resetContext } from './context'
 
 export { kea, connect } from './kea'
+
 export { useValues, useAllValues, useActions, useMountedLogic, useKea } from './react/hooks'
 export { BindLogic } from './react/bind'
+export { Provider } from './react/provider'
 
 export { resetContext, openContext, closeContext, getContext, getPluginContext, setPluginContext } from './context'
 export { getStore } from './store/store'

--- a/src/kea/path.ts
+++ b/src/kea/path.ts
@@ -10,6 +10,7 @@ export function getPathForInput(input: LogicInput, props?: Props): PathType {
 
   const {
     input: { logicPathCreators },
+    options: { defaultPath },
   } = getContext()
 
   let pathCreator = logicPathCreators.get(input)
@@ -21,9 +22,9 @@ export function getPathForInput(input: LogicInput, props?: Props): PathType {
   const count = (++getContext().input.logicPathCounter).toString()
 
   if (input.key) {
-    pathCreator = ((key: string) => ['kea', 'logic', count, key]) as PathCreator
+    pathCreator = (key: string) => [...defaultPath, count, key]
   } else {
-    pathCreator = () => ['kea', 'logic', count]
+    pathCreator = () => [...defaultPath, count]
   }
 
   logicPathCreators.set(input, pathCreator)

--- a/src/kea/path.ts
+++ b/src/kea/path.ts
@@ -9,24 +9,24 @@ export function getPathForInput(input: LogicInput, props?: Props): PathType {
   }
 
   const {
-    input: { inlinePathCreators },
+    input: { logicPathCreators },
   } = getContext()
 
-  let pathCreator = inlinePathCreators.get(input)
+  let pathCreator = logicPathCreators.get(input)
 
   if (pathCreator) {
     return pathCreator(key)
   }
 
-  const count = (++getContext().input.inlinePathCounter).toString()
+  const count = (++getContext().input.logicPathCounter).toString()
 
   if (input.key) {
-    pathCreator = ((key: string) => ['kea', 'inline', count, key]) as PathCreator
+    pathCreator = ((key: string) => ['kea', 'logic', count, key]) as PathCreator
   } else {
-    pathCreator = () => ['kea', 'inline', count]
+    pathCreator = () => ['kea', 'logic', count]
   }
 
-  inlinePathCreators.set(input, pathCreator)
+  logicPathCreators.set(input, pathCreator)
 
   return pathCreator(key)
 }

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -69,12 +69,20 @@ export function useMountedLogic(logic: BuiltLogic | LogicWrapper): BuiltLogic {
     pathString.current = builtLogic.pathString
   }
 
-  useEffect(
-    () => () => {
+  useEffect(function useMountedLogicEffect () {
+    // React Fast Refresh calls `useMountedLogicEffectCleanup` followed directly by `useMountedLogicEffect`.
+    // Thus if we're here and there's still no `unmount.current`, it's because we just refreshed.
+    // Normally we still mount the logic sync in the component, just to have the data there when selectors fire.
+    if (!unmount.current) {
+      unmount.current = builtLogic.mount()
+      pathString.current = builtLogic.pathString
+    }
+
+    return function useMountedLogicEffectCleanup() {
       unmount.current && unmount.current()
-    },
-    [],
-  )
+      unmount.current = undefined
+    }
+  }, [])
 
   return builtLogic
 }

--- a/src/react/provider.tsx
+++ b/src/react/provider.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+import { Provider as ReactReduxProvider } from 'react-redux'
+import { getContext } from '../context'
+
+export function Provider({ children }: { children: React.ReactNode }): JSX.Element {
+  return <ReactReduxProvider store={getContext().store}>{children}</ReactReduxProvider>
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,6 +278,7 @@ export interface InternalContextOptions {
   flatDefaults: boolean
   attachStrategy: 'dispatch' | 'replace'
   detachStrategy: 'dispatch' | 'replace' | 'persist'
+  defaultPath: string[]
   // ...otherOptions
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -342,8 +342,8 @@ export interface Context {
   }
 
   input: {
-    inlinePathCreators: Map<LogicInput, PathCreator<any>>
-    inlinePathCounter: number
+    logicPathCreators: Map<LogicInput, PathCreator<any>>
+    logicPathCounter: number
     defaults: Record<string, any> | undefined
   }
 

--- a/test/jest/connect.js
+++ b/test/jest/connect.js
@@ -88,20 +88,20 @@ test('connect works as an object', () => {
     </Provider>,
   )
 
-  expect(store.getState()).toEqual({ kea: { inline: { 1: { name: 'chirpy' }, 2: { description: 'default' } } } })
+  expect(store.getState()).toEqual({ kea: { logic: { 1: { name: 'chirpy' }, 2: { description: 'default' } } } })
 
   expect(wrapper.find('.id').text()).toEqual('12')
   expect(wrapper.find('.name').text()).toEqual('chirpy')
   expect(wrapper.find('.capitalizedName').text()).toEqual('Chirpy')
   expect(wrapper.find('.description').text()).toEqual('default')
 
-  expect(store.getState()).toEqual({ kea: { inline: { 1: { name: 'chirpy' }, 2: { description: 'default' } } } })
+  expect(store.getState()).toEqual({ kea: { logic: { 1: { name: 'chirpy' }, 2: { description: 'default' } } } })
 
   logic.actions.updateName('somename')
   connectedLogic.actions.updateDescription('new description')
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 1: { name: 'somename' }, 2: { description: 'new description' } } },
+    kea: { logic: { 1: { name: 'somename' }, 2: { description: 'new description' } } },
   })
 
   wrapper.render()
@@ -191,20 +191,20 @@ test('connect works as a function', () => {
     </Provider>,
   )
 
-  expect(store.getState()).toEqual({ kea: { inline: { 1: { name: 'chirpy' }, 2: { description: 'default' } } } })
+  expect(store.getState()).toEqual({ kea: { logic: { 1: { name: 'chirpy' }, 2: { description: 'default' } } } })
 
   expect(wrapper.find('.id').text()).toEqual('12')
   expect(wrapper.find('.name').text()).toEqual('chirpy')
   expect(wrapper.find('.capitalizedName').text()).toEqual('Chirpy')
   expect(wrapper.find('.description').text()).toEqual('default')
 
-  expect(store.getState()).toEqual({ kea: { inline: { 1: { name: 'chirpy' }, 2: { description: 'default' } } } })
+  expect(store.getState()).toEqual({ kea: { logic: { 1: { name: 'chirpy' }, 2: { description: 'default' } } } })
 
   store.dispatch(logic.actionCreators.updateName('somename'))
   store.dispatch(connectedLogic.actionCreators.updateDescription('new description'))
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 1: { name: 'somename' }, 2: { description: 'new description' } } },
+    kea: { logic: { 1: { name: 'somename' }, 2: { description: 'new description' } } },
   })
 
   wrapper.render()
@@ -296,7 +296,7 @@ test('props cascade when connecting', () => {
   )
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 1: { name: 'chirpy-12' }, 2: { description: 'this is a bird' } } },
+    kea: { logic: { 1: { name: 'chirpy-12' }, 2: { description: 'this is a bird' } } },
   })
 
   expect(wrapper.find('.id').text()).toEqual('12')
@@ -308,7 +308,7 @@ test('props cascade when connecting', () => {
   connectedLogic.actions.updateDescription('new description')
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 1: { name: 'somename' }, 2: { description: 'new description' } } },
+    kea: { logic: { 1: { name: 'somename' }, 2: { description: 'new description' } } },
   })
 
   wrapper.render()

--- a/test/jest/context.js
+++ b/test/jest/context.js
@@ -26,8 +26,8 @@ test('getting and setting works', () => {
     },
 
     input: {
-      inlinePathCreators: new Map(),
-      inlinePathCounter: 0,
+      logicPathCreators: new Map(),
+      logicPathCounter: 0,
       defaults: undefined,
     },
 
@@ -128,52 +128,52 @@ test('context works with plugins', () => {
   })
 })
 
-test('inlinePathCreators work as expected', () => {
+test('logicPathCreators work as expected', () => {
   expect(getContext()).not.toBeDefined()
 
   openContext()
   expect(getContext()).toBeDefined()
 
   const {
-    input: { inlinePathCreators },
+    input: { logicPathCreators },
   } = getContext()
 
   const input = {
     path: () => ['kea', 'misc', 'blue'],
   }
   kea(input).build()
-  expect(inlinePathCreators.get(input)).not.toBeDefined()
+  expect(logicPathCreators.get(input)).not.toBeDefined()
 
   const dynamicInput = {
     key: props => props.id,
     path: key => ['kea', 'misc', 'green', key],
   }
   kea(dynamicInput).build({ id: 12 })
-  expect(inlinePathCreators.get(dynamicInput)).not.toBeDefined()
+  expect(logicPathCreators.get(dynamicInput)).not.toBeDefined()
 
   const pathlessInput1 = {}
   kea(pathlessInput1).build()
   expect(
-    inlinePathCreators
+    logicPathCreators
       .get(pathlessInput1)()
       .join('.'),
-  ).toBe('kea.inline.1')
+  ).toBe('kea.logic.1')
 
   const pathlessInput2 = {}
   kea(pathlessInput2).build()
   expect(
-    inlinePathCreators
+    logicPathCreators
       .get(pathlessInput2)()
       .join('.'),
-  ).toBe('kea.inline.2')
+  ).toBe('kea.logic.2')
 
   const keyNoPathInput2 = { key: props => props.id }
   kea(keyNoPathInput2).build({ id: 12 })
   expect(
-    inlinePathCreators
+    logicPathCreators
       .get(keyNoPathInput2)(12)
       .join('.'),
-  ).toBe('kea.inline.3.12')
+  ).toBe('kea.logic.3.12')
 })
 
 test('nested context defaults work', () => {

--- a/test/jest/context.js
+++ b/test/jest/context.js
@@ -145,35 +145,47 @@ test('logicPathCreators work as expected', () => {
   expect(logicPathCreators.get(input)).not.toBeDefined()
 
   const dynamicInput = {
-    key: props => props.id,
-    path: key => ['kea', 'misc', 'green', key],
+    key: (props) => props.id,
+    path: (key) => ['kea', 'misc', 'green', key],
   }
   kea(dynamicInput).build({ id: 12 })
   expect(logicPathCreators.get(dynamicInput)).not.toBeDefined()
 
   const pathlessInput1 = {}
   kea(pathlessInput1).build()
-  expect(
-    logicPathCreators
-      .get(pathlessInput1)()
-      .join('.'),
-  ).toBe('kea.logic.1')
+  expect(logicPathCreators.get(pathlessInput1)().join('.')).toBe('kea.logic.1')
 
   const pathlessInput2 = {}
   kea(pathlessInput2).build()
-  expect(
-    logicPathCreators
-      .get(pathlessInput2)()
-      .join('.'),
-  ).toBe('kea.logic.2')
+  expect(logicPathCreators.get(pathlessInput2)().join('.')).toBe('kea.logic.2')
 
-  const keyNoPathInput2 = { key: props => props.id }
+  const keyNoPathInput2 = { key: (props) => props.id }
   kea(keyNoPathInput2).build({ id: 12 })
-  expect(
-    logicPathCreators
-      .get(keyNoPathInput2)(12)
-      .join('.'),
-  ).toBe('kea.logic.3.12')
+  expect(logicPathCreators.get(keyNoPathInput2)(12).join('.')).toBe('kea.logic.3.12')
+})
+
+describe('defaultPath', () => {
+  test('defaultPath work as expected', () => {
+    openContext({
+      defaultPath: ['kea', 'inline'],
+    })
+
+    kea({
+      reducers: {
+        hi: ['true', {}],
+      },
+    }).mount()
+
+    expect(getContext().store.getState()).toEqual({
+      kea: {
+        inline: {
+          1: {
+            hi: 'true',
+          },
+        },
+      },
+    })
+  })
 })
 
 test('nested context defaults work', () => {

--- a/test/jest/defaults.js
+++ b/test/jest/defaults.js
@@ -179,21 +179,21 @@ test('defaults from selectors', () => {
   expect(wrapper.find('.directName').text()).toEqual('storedName')
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 1: { storedName: 'storedName' } } },
+    kea: { logic: { 1: { storedName: 'storedName' } } },
     scenes: { dynamic: { connectedName: 'storedName', directName: 'storedName' } },
   })
 
   store.dispatch(singletonLogic.actionCreators.updateStoredName('birb'))
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 1: { storedName: 'birb' } } },
+    kea: { logic: { 1: { storedName: 'birb' } } },
     scenes: { dynamic: { connectedName: 'storedName', directName: 'storedName' } },
   })
 
   singletonLogic.actions.updateName('birb')
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 1: { storedName: 'birb' } } },
+    kea: { logic: { 1: { storedName: 'birb' } } },
     scenes: { dynamic: { connectedName: 'birb', directName: 'birb' } },
   })
 
@@ -302,21 +302,21 @@ test('defaults from input.defaults selector', () => {
   expect(wrapper.find('.directName').text()).toEqual('storedName')
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 1: { storedName: 'storedName' } } },
+    kea: { logic: { 1: { storedName: 'storedName' } } },
     scenes: { dynamic: { 12: { connectedName: 'storedName', directName: 'storedName' } } },
   })
 
   dynamicLogic({ id: 12 }).actions.updateStoredName('birb')
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 1: { storedName: 'birb' } } },
+    kea: { logic: { 1: { storedName: 'birb' } } },
     scenes: { dynamic: { 12: { connectedName: 'storedName', directName: 'storedName' } } },
   })
 
   store.dispatch(dynamicLogic({ id: 12 }).actionCreators.updateName('birb'))
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 1: { storedName: 'birb' } } },
+    kea: { logic: { 1: { storedName: 'birb' } } },
     scenes: { dynamic: { 12: { connectedName: 'birb', directName: 'birb' } } },
   })
 
@@ -388,13 +388,13 @@ test('defaults from props via input.defaults without selector', () => {
   expect(wrapper.find('.capitalizedName').text()).toEqual('Defaultname')
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 1: { propsName: 'defaultName' } } },
+    kea: { logic: { 1: { propsName: 'defaultName' } } },
   })
 
   lazyLogic.actions.updateName('birb')
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 1: { propsName: 'birb' } } },
+    kea: { logic: { 1: { propsName: 'birb' } } },
   })
 
   wrapper.render()
@@ -496,19 +496,19 @@ test('defaults from selectors in input.defaults without selector', () => {
   expect(wrapper.find('.directName').text()).toEqual('george')
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 2: { storedName: 'storedName' }, 1: { connectedName: 'storedName', directName: 'george' } } },
+    kea: { logic: { 2: { storedName: 'storedName' }, 1: { connectedName: 'storedName', directName: 'george' } } },
   })
 
   singletonLogic.actions.updateStoredName('birb')
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 2: { storedName: 'birb' }, 1: { connectedName: 'storedName', directName: 'george' } } },
+    kea: { logic: { 2: { storedName: 'birb' }, 1: { connectedName: 'storedName', directName: 'george' } } },
   })
 
   store.dispatch(singletonLogic.actionCreators.updateName('birb'))
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 2: { storedName: 'birb' }, 1: { connectedName: 'birb', directName: 'birb' } } },
+    kea: { logic: { 2: { storedName: 'birb' }, 1: { connectedName: 'birb', directName: 'birb' } } },
   })
 
   wrapper.render()
@@ -599,7 +599,7 @@ test('defaults from input.defaults as object', () => {
   expect(wrapper.find('.directName').text()).toEqual('george')
 
   expect(store.getState()).toEqual({
-    kea: { inline: { 1: { propsName: 'defaultName', connectedName: 'storedName', directName: 'george' } } },
+    kea: { logic: { 1: { propsName: 'defaultName', connectedName: 'storedName', directName: 'george' } } },
   })
 
   wrapper.unmount()
@@ -702,7 +702,7 @@ test('defaults from selector that returns an object', () => {
 
   expect(store.getState()).toEqual({
     kea: {
-      inline: {
+      logic: {
         1: { propsName: 'henry', connectedName: 'george', directName: 'joe' },
         2: { object: { propsName: 'henry', connectedName: 'george', directName: 'joe' } },
       },

--- a/test/jest/errors.js
+++ b/test/jest/errors.js
@@ -36,7 +36,7 @@ test('building broken selectors throws a nice error', () => {
 
   expect(() => {
     logic.build()
-  }).toThrow('[KEA] Logic "kea.inline.1", selector "anotherThing" has incorrect input: [function, undefined].')
+  }).toThrow('[KEA] Logic "kea.logic.1", selector "anotherThing" has incorrect input: [function, undefined].')
 })
 
 test('connecting to something that does not exist gives an error', () => {
@@ -51,7 +51,7 @@ test('connecting to something that does not exist gives an error', () => {
         values: [undefined, ['notThere']],
       },
     }).build()
-  }).toThrow('[KEA] Logic "kea.inline.2" can not connect to undefined to request prop "notThere"')
+  }).toThrow('[KEA] Logic "kea.logic.2" can not connect to undefined to request prop "notThere"')
 
   expect(() => {
     kea({
@@ -59,7 +59,7 @@ test('connecting to something that does not exist gives an error', () => {
         values: [logic, ['notThere']],
       },
     }).build()
-  }).toThrow('[KEA] Logic "kea.inline.3", connecting to prop "notThere" returns \'undefined\'')
+  }).toThrow('[KEA] Logic "kea.logic.3", connecting to prop "notThere" returns \'undefined\'')
 
   expect(() => {
     kea({
@@ -67,7 +67,7 @@ test('connecting to something that does not exist gives an error', () => {
         values: ['haha', ['notThere']],
       },
     }).build()
-  }).toThrow('[KEA] Logic "kea.inline.4" can not connect to string to request prop "notThere"')
+  }).toThrow('[KEA] Logic "kea.logic.4" can not connect to string to request prop "notThere"')
 
   expect(() => {
     kea({
@@ -75,7 +75,7 @@ test('connecting to something that does not exist gives an error', () => {
         actions: [undefined, ['notThere']],
       },
     }).build()
-  }).toThrow('[KEA] Logic "kea.inline.5" can not connect to undefined to request action "notThere"')
+  }).toThrow('[KEA] Logic "kea.logic.5" can not connect to undefined to request action "notThere"')
 
   expect(() => {
     kea({
@@ -83,7 +83,7 @@ test('connecting to something that does not exist gives an error', () => {
         actions: [logic, ['notThere']],
       },
     }).build()
-  }).toThrow('[KEA] Logic "kea.inline.6", connecting to action "notThere" returns \'undefined\'')
+  }).toThrow('[KEA] Logic "kea.logic.6", connecting to action "notThere" returns \'undefined\'')
 
   expect(() => {
     kea({
@@ -91,7 +91,7 @@ test('connecting to something that does not exist gives an error', () => {
         actions: ['haha', ['notThere']],
       },
     }).build()
-  }).toThrow('[KEA] Logic "kea.inline.7" can not connect to string to request action "notThere"')
+  }).toThrow('[KEA] Logic "kea.logic.7" can not connect to string to request action "notThere"')
 })
 
 test('reducers with undefined actions throw', () => {
@@ -113,7 +113,7 @@ test('reducers with undefined actions throw', () => {
   expect(() => {
     logic.build()
   }).toThrow(
-    '[KEA] Logic "kea.inline.1" reducer "thingie" is waiting for an action that is undefined: [do something (kea.inline.1), undefined]',
+    '[KEA] Logic "kea.logic.1" reducer "thingie" is waiting for an action that is undefined: [do something (kea.logic.1), undefined]',
   )
 })
 

--- a/test/jest/extend.js
+++ b/test/jest/extend.js
@@ -42,7 +42,7 @@ test('can extend with .extend', () => {
   expect(Object.keys(logic.build().actions).sort()).toEqual(['doit', 'domore'])
 })
 
-test('can extend with inline .extend', () => {
+test('can extend with .extend', () => {
   const logic = kea({
     actions: () => ({
       doit: true,
@@ -95,7 +95,7 @@ test('can extend multiple times with .extend', () => {
   expect(Object.keys(logic.build().actions).sort()).toEqual(['doevenmore', 'doit', 'domore'])
 })
 
-test('can extend multiple times with inline .extend', () => {
+test('can extend multiple times with .extend', () => {
   const logic = kea({
     actions: () => ({
       doit: true,

--- a/test/jest/hooks.js
+++ b/test/jest/hooks.js
@@ -344,7 +344,7 @@ test('can change key/path of logic once it has been accessed in a hook', () => {
   })
 })
 
-test('can define logic inline with useKea', () => {
+test('can define logic with useKea', () => {
   const { store } = getContext()
 
   function SampleComponent({ id }) {

--- a/test/jest/selectors-props.js
+++ b/test/jest/selectors-props.js
@@ -60,7 +60,7 @@ test("selectors have access to the component's props", () => {
   expect(wrapper.find('#book-2').text()).toEqual('book2')
 
   // only one of the components should be in the store, as only one has a reducer
-  expect(Object.keys(store.getState().kea.inline).length).toEqual(1)
+  expect(Object.keys(store.getState().kea.logic).length).toEqual(1)
 
   wrapper.unmount()
 })


### PR DESCRIPTION
## 2.4.0 - 2021-05-02
- **Possibly Breaking:** Changed the [default path](https://kea.js.org/docs/guide/debugging#logic-path) for logic 
  without a `path` (or when not using the kea babel plugin) from `kea.inline` to `kea.logic`. If you have ever hardcoded 
  `"kea.inline"` anywhere, perhaps in tests, this will cause a bit of headache. If you need it set at `kea.inline`, use 
  `resetContext({ defaultPath: ['kea', 'inline'] })`.
- Added `<Provider />` tag to simplify calling React-Redux's `<Provider store={getContext().store} />`.
- Fixed crashes with [React Fast Refresh](https://github.com/keajs/kea/issues/119).
