### PR TITLE
Kea 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,11 @@ const logic = kea({
     something: [
       null,
       {
-        // This `yetAnotherLogic` will still get connected automatically, not print a warning, and not require `connect`.
-        // However it's still good practice to explicitly define your dependencies.
-        [yetAnotherLogic.actionTypes.loadSessions]: () => 'yes',
+          // This `yetAnotherLogic` will still get connected automatically, not print a warning, 
+          // and not require `connect`. That's because it's connected directly at build time, whereas
+          // in the listener, we're running within an asynchronous callback coming from who knows where. 
+          // While this works, it's still good practice to explicitly define your dependencies.
+          [yetAnotherLogic.actionTypes.loadSessions]: () => 'yes',
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -61,11 +61,10 @@
     }
   },
   "peerDependencies": {
-    "kea": ">= 2",
     "react": ">= 16",
-    "react-redux": ">= 7",
-    "redux": ">= 3",
-    "reselect": ">= 2"
+    "react-redux": ">= 8",
+    "redux": ">= 4.2",
+    "reselect": ">= 4.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.5",
@@ -119,10 +118,10 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-redux": "^7.2.4",
+    "react-redux": "^8.0.1",
     "react-test-renderer": "^17.0.2",
-    "redux": "^4.1.0",
-    "reselect": "^4.0.0",
+    "redux": "^4.2.0",
+    "reselect": "^4.1.5",
     "rimraf": "^3.0.2",
     "rollup": "^2.52.7",
     "rollup-plugin-dts": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "react": ">= 16",
-    "react-redux": ">= 8",
+    "react-redux": ">= 7",
     "redux": ">= 4.2",
     "reselect": ">= 4.1"
   },
@@ -118,7 +118,7 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-redux": "^8.0.1",
+    "react-redux": "^7.0.1",
     "react-test-renderer": "^17.0.2",
     "redux": "^4.2.0",
     "reselect": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     }
   },
   "peerDependencies": {
-    "react": ">= 16",
+    "react": ">= 16.8",
     "react-redux": ">= 7",
     "redux": ">= 4.2",
     "reselect": ">= 4.1"

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -76,7 +76,7 @@ export function openContext(options: ContextOptions = {}, initial = false): Cont
       debug: false,
       autoMount: false,
       autoConnect: true,
-      autoConnectMountWarning: false,
+      autoConnectMountWarning: true,
       proxyFields: true,
       flatDefaults: false,
       attachStrategy: 'dispatch',

--- a/src/core/steps/selectors.ts
+++ b/src/core/steps/selectors.ts
@@ -33,7 +33,7 @@ export function createSelectors(logic: Logic, input: LogicInput): void {
   })
 
   Object.keys(selectorInputs).forEach((key) => {
-    const [input, func, type, isEqual] = selectorInputs[key]!
+    const [input, func, type, memoizeOptions] = selectorInputs[key]!
     const args = input(logic.selectors) as ParametricSelector<any, any, any>[]
 
     if (type) {
@@ -48,7 +48,7 @@ export function createSelectors(logic: Logic, input: LogicInput): void {
       }
     }
 
-    builtSelectors[key] = (isEqual ? createSelectorCreator(defaultMemoize, isEqual) : createSelector)(args, func)
+    builtSelectors[key] = createSelector(args, func, { memoizeOptions })
     logic.selectors[key] = (state = getStoreState(), props = logic.props) => builtSelectors[key](state, props)
   })
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { Reducer, Store, Action as ReduxAction, Middleware, StoreEnhancer, compose, AnyAction } from 'redux'
 import { Context as ReactContext, ComponentType, FunctionComponent } from 'react'
+import { DefaultMemoizeOptions } from 'reselect'
 
 // universal helpers
 export type AnyComponent = ComponentType | FunctionComponent
@@ -131,12 +132,10 @@ export type SelectorTuple =
   | [Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector]
   | [Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector]
 
-export type IsEqualsComparison = (a: any, b: any) => boolean
-
 export type SelectorDefinition<Selectors, SelectorFunction extends any> =
   | [(s: Selectors) => SelectorTuple, SelectorFunction]
   | [(s: Selectors) => SelectorTuple, SelectorFunction, any]
-  | [(s: Selectors) => SelectorTuple, SelectorFunction, any, IsEqualsComparison]
+  | [(s: Selectors) => SelectorTuple, SelectorFunction, any, DefaultMemoizeOptions]
 
 type SelectorDefinitions<LogicType extends Logic> =
   | {

--- a/test/jest/selectors.js
+++ b/test/jest/selectors.js
@@ -143,7 +143,7 @@ test('support custom memoization functions', () => {
       reversedValuesIfLengthChanges: [
         (s) => [s.values, () => 1],
         (values, _discarded) => [...values].reverse(),
-        null,
+        null, // PropTypes, will be removed in Kea 3.0
         { resultEqualityCheck: (a, b) => a.length === b.length },
       ],
     },

--- a/test/jest/selectors.js
+++ b/test/jest/selectors.js
@@ -141,10 +141,10 @@ test('support custom memoization functions', () => {
     selectors: {
       reversedValues: [(s) => [s.values], (values) => [...values].reverse()],
       reversedValuesIfLengthChanges: [
-        (s) => [s.values],
-        (values) => [...values].reverse(),
+        (s) => [s.values, () => 1],
+        (values, _discarded) => [...values].reverse(),
         null,
-        (a, b) => a.length === b.length,
+        { resultEqualityCheck: (a, b) => a.length === b.length },
       ],
     },
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,7 +1483,7 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/hoist-non-react-statics@^3.3.0":
+"@types/hoist-non-react-statics@^3.3.0", "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
   integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
@@ -1605,6 +1605,11 @@
   integrity sha512-l2P2GO+hFF4Liye+fAajT1qBqvZOiL79YMpEvgGs1xTK7hECxBI8Wz4J7ntACJNiJ9r0vXQqYovroXRLPDja6A==
   dependencies:
     "@types/jest" "*"
+
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -5328,22 +5333,27 @@ react-dom@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-redux@^7.2.4:
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.4.tgz#1ebb474032b72d806de2e0519cd07761e222e225"
-  integrity sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==
+react-is@^18.0.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"
+  integrity sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==
+
+react-redux@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.0.1.tgz#2bc029f5ada9b443107914c373a2750f6bc0f40c"
+  integrity sha512-LMZMsPY4DYdZfLJgd7i79n5Kps5N9XVLCJJeWAaPYTV+Eah2zTuBjTxKtNEbjiyitbq80/eIkm55CYSLqAub3w==
   dependencies:
     "@babel/runtime" "^7.12.1"
-    "@types/react-redux" "^7.1.16"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/use-sync-external-store" "^0.0.3"
     hoist-non-react-statics "^3.3.2"
-    loose-envify "^1.4.0"
-    prop-types "^15.7.2"
-    react-is "^16.13.1"
+    react-is "^18.0.0"
+    use-sync-external-store "^1.0.0"
 
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
@@ -5459,10 +5469,17 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-redux@^4.0.0, redux@^4.1.0:
+redux@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.0.tgz#eb049679f2f523c379f1aff345c8612f294c88d4"
   integrity sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
+redux@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
+  integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==
   dependencies:
     "@babel/runtime" "^7.9.2"
 
@@ -5607,10 +5624,10 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
-reselect@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
-  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+reselect@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -6472,6 +6489,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+use-sync-external-store@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz#3343c3fe7f7e404db70f8c687adf5c1652d34e82"
+  integrity sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2227,9 +2227,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001242"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz#04201627abcd60dc89211f22cbe2347306cda46b"
-  integrity sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==
+  version "1.0.30001338"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz"
+  integrity sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,10 +1051,17 @@
     core-js-pure "^3.15.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
   integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.15.4":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1483,7 +1490,7 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/hoist-non-react-statics@^3.3.0", "@types/hoist-non-react-statics@^3.3.1":
+"@types/hoist-non-react-statics@^3.3.0":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
   integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
@@ -1573,6 +1580,16 @@
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
+"@types/react-redux@^7.1.20":
+  version "7.1.24"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.24.tgz#6caaff1603aba17b27d20f8ad073e4c077e975c0"
+  integrity sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
 "@types/react@*", "@types/react@^17.0.13":
   version "17.0.13"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.13.tgz#6b7c9a8f2868586ad87d941c02337c6888fb874f"
@@ -1605,11 +1622,6 @@
   integrity sha512-l2P2GO+hFF4Liye+fAajT1qBqvZOiL79YMpEvgGs1xTK7hECxBI8Wz4J7ntACJNiJ9r0vXQqYovroXRLPDja6A==
   dependencies:
     "@types/jest" "*"
-
-"@types/use-sync-external-store@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
-  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -5338,22 +5350,17 @@ react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^18.0.0:
-  version "18.1.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"
-  integrity sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==
-
-react-redux@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.0.1.tgz#2bc029f5ada9b443107914c373a2750f6bc0f40c"
-  integrity sha512-LMZMsPY4DYdZfLJgd7i79n5Kps5N9XVLCJJeWAaPYTV+Eah2zTuBjTxKtNEbjiyitbq80/eIkm55CYSLqAub3w==
+react-redux@^7.0.1:
+  version "7.2.8"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.8.tgz#a894068315e65de5b1b68899f9c6ee0923dd28de"
+  integrity sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==
   dependencies:
-    "@babel/runtime" "^7.12.1"
-    "@types/hoist-non-react-statics" "^3.3.1"
-    "@types/use-sync-external-store" "^0.0.3"
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
     hoist-non-react-statics "^3.3.2"
-    react-is "^18.0.0"
-    use-sync-external-store "^1.0.0"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
@@ -6489,11 +6496,6 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
-
-use-sync-external-store@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz#3343c3fe7f7e404db70f8c687adf5c1652d34e82"
-  integrity sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
## Kea 2.6

- Update version requirements of peer dependencies: `reselect` 4.1+, `redux` 4.2+, `react-redux` 7+ and `react` 16.8+.
- If you're using React 18, upgrade `react-redux` to version 8+.

- Add a "redux listener silencing store enhancer", which prevents Redux's `useSelector`s from updating, when mounting a logic from within the body of a React component (e.g. with `useValues`).
This effectively silences log spam in React 18 (`Warning: Cannot update a component (`Y`) while rendering a different component (`X`). To locate the bad setState() call inside `X`, follow the stack trace as described.`), and improves performance.

- Set the `autoConnectMountWarning` option to `true` by default. Kea 2.0 introduced ["auto-connect"](https://keajs.org/blog/kea-2.0#auto-connect),
  and while it works great in reducers and selectors, automatically connecting logic in listeners turned out to be a bad idea.
  Thus, in Kea 2.6, when accessing values on an unmounted logic, you'll get a warning by default. In Kea 3.0, it will trigger an error.

```js
import { kea } from 'kea'
import { otherLogic } from './otherLogic'
import { yetAnotherLogic } from './yetAnotherLogic'

const logic = kea({
  // connect: [otherLogic], // should have been explicitly connected like this, or mounted outside the logic
  actions: { doSomething: true },
  listeners: {
    doSomething: () => {
      // This will now print a warning if `otherLogic` is not mounted.
      console.log(otherLogic.values.situation)
    },
  },
  reducers: {
    something: [
      null,
      {
        // This `yetAnotherLogic` will still get connected automatically, not print a warning, 
        // and not require `connect`. That's because it's connected directly at build time, whereas
        // in the listener, we're running within an asynchronous callback coming from who knows where. 
        // While this works, it's still good practice to explicitly define your dependencies.
        [yetAnotherLogic.actionTypes.loadSessions]: () => 'yes',
      },
    ],
  },
})
```

- Support custom selector memoization. Use [`memoizeOptions`](https://github.com/reduxjs/reselect#defaultmemoizefunc-equalitycheckoroptions--defaultequalitycheck) as the 4th `selector` array value, which is then passed directly to reselect:

```js
const logic = kea({
  selectors: {
    widgetKeys: [
      (selectors) => [selectors.widgets],
      (widgets) => Object.keys(widgets),
      null, // PropTypes, will be removed in Kea 3.0
      { resultEqualityCheck: deepEqual },
    ],
  },
})
```
