### PR TITLE
Logic prop selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## 3.0.4 - 2022-10-01
+
+- Support "prop selectors" in selectors. Now `p.id` is a shorthand for `(_, props) => props.id`. For example:
+
+```ts
+const logic = kea([
+  props({} as { id: number }),
+  selectors({
+    duckAndChicken: [
+      (s, p) => [s.duckId, s.chickenId, p.id],
+      (duckId, chickenId, id) => duckId + chickenId + id,
+    ],
+  })
+])
+```
+
 ## 3.0.3 - 2022-09-20
 
 - Show better errors in production

--- a/src/core/selectors.ts
+++ b/src/core/selectors.ts
@@ -5,7 +5,7 @@ import { getStoreState } from '../kea/context'
 /**
   Logic builder:
       props({} as { id: number })
-      selector({
+      selectors({
         duckAndChicken: [
           (s, p) => [s.duckId, s.chickenId, p.id],
           (duckId, chickenId, id) => duckId + chickenId + id,

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,15 +88,13 @@ export type LogicBuilder<L extends Logic = Logic> = (logic: BuiltLogic<L>) => vo
 // input helpers (using the generated logic type as input)
 export type PayloadCreatorDefinition = true | ((...args: any[]) => any)
 export type ActionDefinitions<LogicType extends Logic> = LogicType['actionCreators'] extends Record<string, any>
-  ? Partial<
-      {
-        [K in keyof LogicType['actionCreators']]: LogicType['actionCreators'][K] extends Function
-          ? ReturnType<LogicType['actionCreators'][K]>['payload']['value'] extends true
-            ? true
-            : (...args: Parameters<LogicType['actionCreators'][K]>) => LogicType['actionCreators'][K]['payload']
-          : never
-      }
-    >
+  ? Partial<{
+      [K in keyof LogicType['actionCreators']]: LogicType['actionCreators'][K] extends Function
+        ? ReturnType<LogicType['actionCreators'][K]>['payload']['value'] extends true
+          ? true
+          : (...args: Parameters<LogicType['actionCreators'][K]>) => LogicType['actionCreators'][K]['payload']
+        : never
+    }>
   : Record<string, PayloadCreatorDefinition>
 
 export interface KeaReduxAction extends AnyAction {
@@ -126,13 +124,12 @@ export type ReducerActions<
         state: ReducerType,
         payload: ReturnType<LogicType['actionCreators'][K]>['payload'],
       ) => ReducerType
-    } &
-      {
-        [K in keyof LogicType['__keaTypeGenInternalReducerActions']]?: (
-          state: ReducerType,
-          payload: ReturnType<LogicType['__keaTypeGenInternalReducerActions'][K]>['payload'],
-        ) => ReducerType
-      }
+    } & {
+      [K in keyof LogicType['__keaTypeGenInternalReducerActions']]?: (
+        state: ReducerType,
+        payload: ReturnType<LogicType['__keaTypeGenInternalReducerActions'][K]>['payload'],
+      ) => ReducerType
+    }
   : never
 
 export type ReducerDefault<Reducer extends () => any, P extends Props> =
@@ -170,19 +167,24 @@ export type SelectorTuple =
   | [Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector]
   | [Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector, Selector]
 
-export type SelectorDefinition<Selectors, SelectorFunction extends any> =
-  | [(s: Selectors) => SelectorTuple, SelectorFunction]
-  | [(s: Selectors) => SelectorTuple, SelectorFunction, DefaultMemoizeOptions]
+export type SelectorDefinition<Selectors, PropSelectors, SelectorFunction extends any> =
+  | [(s: Selectors, p: PropSelectors) => SelectorTuple, SelectorFunction]
+  | [(s: Selectors, p: PropSelectors) => SelectorTuple, SelectorFunction, DefaultMemoizeOptions]
+
+export type LogicPropSelectors<LogicType extends Logic> = {
+  [PK in keyof LogicType['props']]: () => LogicType['props'][PK]
+}
 
 export type SelectorDefinitions<LogicType extends Logic> =
   | {
       [K in keyof LogicType['__keaTypeGenInternalSelectorTypes']]?: SelectorDefinition<
         LogicType['selectors'],
+        LogicPropSelectors<LogicType>,
         LogicType['__keaTypeGenInternalSelectorTypes'][K]
       >
     }
   | {
-      [key: string]: SelectorDefinition<LogicType['selectors'], any>
+      [key: string]: SelectorDefinition<LogicType['selectors'], LogicPropSelectors<LogicType>, any>
     }
 
 export type BreakPointFunction = (() => void) & ((ms: number) => Promise<void>)

--- a/test/jest/selectors.js
+++ b/test/jest/selectors.js
@@ -1,4 +1,4 @@
-import { kea, resetContext, actions, reducers, selectors } from '../../src'
+import { kea, resetContext, actions, reducers, selectors, key } from '../../src'
 
 describe('selectors', () => {
   beforeEach(() => {
@@ -173,5 +173,44 @@ describe('selectors', () => {
     expect(logic.values.values).toEqual(['first', 'SECOND', 'third'])
     expect(logic.values.reversedValues).toEqual(['third', 'SECOND', 'first'])
     expect(logic.values.reversedValuesIfLengthChanges).toEqual(['third', 'SECOND', 'first'])
+  })
+
+  test('props selectors', () => {
+    const logic = kea([
+      key((props) => props.id),
+      selectors({
+        id: [
+          (s, p) => [p.id],
+          (id) => {
+            return id
+          },
+        ],
+      }),
+    ])
+
+    const builtLogic = logic({ id: 1 })
+    builtLogic.mount()
+
+    expect(builtLogic.values.id).toEqual(1)
+  })
+
+  test('props selectors throw', () => {
+    const logic = kea([
+      key((props) => props.id),
+      selectors({
+        id: [
+          (s, p) => [p.somethingElse],
+          (id) => {
+            return id
+          },
+        ],
+      }),
+    ])
+
+    expect(() => {
+      const builtLogic = logic({ id: 1 })
+    }).toThrow(
+      '[KEA] Prop "somethingElse" not found for logic "kea.logic.1.1". Attempted to use in a selector. Please specify a default via props({ somethingElse: \'\' }) to resolve.',
+    )
   })
 })


### PR DESCRIPTION
Adds support for the following


```ts
const logic = kea([
  props({} as { id: number }),
  selectors({
    duckAndChicken: [
      (s, p) => [s.duckId, s.chickenId, p.id],
      (duckId, chickenId, id) => duckId + chickenId + id,
    ],
  })
])
```