### PR TITLE
fix: handle getState throwing during dispatch in batchChanges

### DIFF
--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -11,6 +11,15 @@ export const isPaused = () => pauseCounter !== 0
 
 const getStoreState = () => getContext().store.getState()
 
+/** Returns undefined instead of throwing if Redux is mid-dispatch. */
+const safeGetStoreState = () => {
+  try {
+    return getStoreState()
+  } catch {
+    return undefined
+  }
+}
+
 export function useSelector(selector: Selector): any {
   return useSyncExternalStore(getContext().store.subscribe, () => selector(getStoreState()))
 }
@@ -103,7 +112,7 @@ let timeout: any
 /** Delay Redux subscriptions from firing and asking React to re-render.
  * Will set a Timeout to flush if store changed during callback. */
 export function batchChanges(callback: () => void) {
-  const previousState = getStoreState()
+  const previousState = safeGetStoreState()
   pauseCounter += 1
   try {
     callback()
@@ -111,7 +120,7 @@ export function batchChanges(callback: () => void) {
   } finally {
     pauseCounter -= 1
   }
-  const newState = getStoreState()
+  const newState = safeGetStoreState()
   if (previousState !== newState) {
     timeout && clearTimeout(timeout)
     timeout = setTimeout(() => getContext().store.dispatch({ type: '@KEA/FLUSH' }), 0)

--- a/test/jest/hooks.js
+++ b/test/jest/hooks.js
@@ -490,6 +490,37 @@ describe('hooks', () => {
     unmount()
   })
 
+  it('batchChanges does not throw when store.getState() is called during dispatch', () => {
+    const { store } = getContext()
+
+    const logic = kea([
+      path(['batchTest']),
+      actions({ doSomething: true }),
+      reducers({ done: [false, { doSomething: () => true }] }),
+    ])
+
+    const unmountLogic = logic.mount()
+
+    const badReducer = (state = {}, action) => {
+      if (action.type === 'TRIGGER_BATCH_DURING_DISPATCH') {
+        batchChanges(() => {
+          unmountLogic()
+        })
+      }
+      return state
+    }
+    store.replaceReducer((state = {}, action) => {
+      return {
+        ...badReducer(state, action),
+        ...getContext().reducers.combined(state, action, state),
+      }
+    })
+
+    expect(() => {
+      store.dispatch({ type: 'TRIGGER_BATCH_DURING_DISPATCH' })
+    }).not.toThrow()
+  })
+
   it('batchChanges works as expected', async () => {
     resetContext({
       createStore: {


### PR DESCRIPTION
Reported in [#52778](https://posthoghelp.zendesk.com/agent/tickets/52778), [error tracking issue](https://us.posthog.com/project/2/error_tracking/019c29c4-3860-7ca0-8d56-3044472de7f4?fce15f96acfea8134c8d4dd96e1812ace42b65db0167d16daa14675c9ca8665d9e8d0a8e3839f0fbf0c402a487d8644a2ff7a75e355a3a691fc49ce79568bcd4&timestamp=2026-03-09%2019%3A57%3A32.371000-07%3A00)

`getState` throws if it's called during dispatches: https://github.com/reduxjs/redux/blob/ab47d947c29f2ce7f47a3a69eb6075a036355248/src/createStore.ts#L176-L183. I think its usage in `batchChanges` is an optimization, so it should be safe to return `undefined`.