### PR TITLE
feat: support metadata in MakeLogicType

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -422,6 +422,7 @@ export interface MakeLogicType<
   Values extends Record<string, any> = Record<string, unknown>,
   Actions = Record<string, AnyFunction>,
   LogicProps = Props,
+  Meta extends KeaLogicTypeInput = {},
 > extends Logic {
   actionCreators: {
     [ActionKey in keyof Actions]: Actions[ActionKey] extends AnyFunction
@@ -448,21 +449,35 @@ export interface MakeLogicType<
   reducers: {
     [Value in keyof Values]: ReducerFunction<Values[Value]>
   }
-  selector: (state: any, props: LogicProps) => Values
+  key: Meta['key'] extends KeyType ? Meta['key'] : KeyType | undefined
+  selector: (state: any, props?: LogicProps) => Values
   selectors: {
-    [Value in keyof Values]: (state: any, props: LogicProps) => Values[Value]
+    [Value in keyof Values]: (state: any, props?: LogicProps) => Values[Value]
   }
+  sharedListeners: Meta['sharedListeners'] extends Record<string, ListenerFunction>
+    ? Meta['sharedListeners']
+    : Record<string, ListenerFunction> | undefined
   values: Values
 
-  __keaTypeGenInternalSelectorTypes: {
-    [K in keyof Values]: (...args: any) => Values[K]
-  }
+  __keaTypeGenInternalSelectorTypes: Meta['__keaTypeGenInternalSelectorTypes'] extends Record<string, any>
+    ? Meta['__keaTypeGenInternalSelectorTypes']
+    : {
+        [K in keyof Values]: (...args: any) => Values[K]
+      }
+  __keaTypeGenInternalReducerActions: Meta['__keaTypeGenInternalReducerActions'] extends Record<string, any>
+    ? Meta['__keaTypeGenInternalReducerActions']
+    : Record<string, any>
+  __keaTypeGenInternalExtraInput: Meta['__keaTypeGenInternalExtraInput'] extends Record<string, any>
+    ? Meta['__keaTypeGenInternalExtraInput']
+    : Record<string, any>
 }
 
 export interface KeaLogicTypeInput {
   values?: Record<string, unknown>
   actions?: Record<string, AnyFunction>
   props?: Props
+  key?: KeyType
+  sharedListeners?: Record<string, ListenerFunction>
 
   __keaTypeGenInternalSelectorTypes?: Record<string, any>
   __keaTypeGenInternalReducerActions?: Record<string, any>
@@ -491,10 +506,14 @@ export interface KeaLogicType<Input extends KeaLogicTypeInput> extends Logic {
   reducers: {
     [Value in keyof Input['values']]: ReducerFunction<Input['values'][Value]>
   }
-  selector: (state: any, props: Input['props']) => Input['values']
+  key: Input['key'] extends KeyType ? Input['key'] : KeyType | undefined
+  selector: (state: any, props?: Input['props']) => Input['values']
   selectors: {
-    [Value in keyof Input['values']]: (state: any, props: Input['props']) => Input['values'][Value]
+    [Value in keyof Input['values']]: (state: any, props?: Input['props']) => Input['values'][Value]
   }
+  sharedListeners: Input['sharedListeners'] extends Record<string, ListenerFunction>
+    ? Input['sharedListeners']
+    : Record<string, ListenerFunction> | undefined
   values: Input['values'] extends Record<string, unknown> ? Input['values'] : Record<string, unknown>
 
   __keaTypeGenInternalSelectorTypes: Input['__keaTypeGenInternalSelectorTypes'] extends Record<string, any>

--- a/test/tsd/index.test-d.ts
+++ b/test/tsd/index.test-d.ts
@@ -10,6 +10,7 @@ import {
   KeaReduxAction,
   KeyType,
   ReducerFunction,
+  ListenerFunction,
   // It's a bit of a hack, but it works! :-)
   // This file is copied to "lib/" and tested against the built bundle, thus we are importing from "." (index.js)
   // ... requiring the following comments:
@@ -78,14 +79,16 @@ expectType<{
   pinned: (state: boolean, action: KeaReduxAction, fullState: any) => boolean
 }>(logic.reducers)
 
-expectType<(state: any, props: DashboardProps) => DashboardValues>(logic.selector)
+expectType<(state: any, props?: DashboardProps) => DashboardValues>(logic.selector)
 
 expectType<{
-  id: (state: any, props: DashboardProps) => number
-  created_at: (state: any, props: DashboardProps) => string
-  name: (state: any, props: DashboardProps) => string
-  pinned: (state: any, props: DashboardProps) => boolean
+  id: (state: any, props?: DashboardProps) => number
+  created_at: (state: any, props?: DashboardProps) => string
+  name: (state: any, props?: DashboardProps) => string
+  pinned: (state: any, props?: DashboardProps) => boolean
 }>(logic.selectors)
+
+logic.selectors.id({})
 
 expectType<{
   id: (...args: any) => number
@@ -113,6 +116,20 @@ expectType<{
   propsChanged?: ((props: any, oldProps: any) => void) | undefined
 }>(logic.events)
 expectType<Record<string, any>>(logic.__keaTypeGenInternalReducerActions)
+
+interface DashboardMeta {
+  key: string
+  sharedListeners: Record<'saveDashboard', ListenerFunction>
+  __keaTypeGenInternalSelectorTypes: {
+    name: (prefix: string) => string
+  }
+}
+
+const logicWithMeta = kea<MakeLogicType<DashboardValues, DashboardActions, DashboardProps, DashboardMeta>>({})
+
+expectType<string>(logicWithMeta.key)
+expectType<Record<'saveDashboard', ListenerFunction>>(logicWithMeta.sharedListeners)
+expectType<(prefix: string) => string>(logicWithMeta.__keaTypeGenInternalSelectorTypes.name)
 
 /*
  * 4. Test Empty Logic


### PR DESCRIPTION
## Summary

- add an optional metadata generic to `MakeLogicType`
- preserve exact keyed logic, shared listener, and internal typegen metadata
- allow selectors to be called without explicitly passing props

## Testing

- `pnpm run test:types`
- `pnpm run test:tsd`